### PR TITLE
feat: Update Makefile with streamlit dashboard targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # filename: Makefile
-.PHONY: help dev-setup install test lint format clean run-simulation run-dashboard docker-build
+.PHONY: help dev-setup install test lint format clean run-simulation run-dashboard run-compensation-tuning run-optimization-dashboard docker-build
 
 PYTHON := python3.11
 VENV := venv
@@ -53,8 +53,14 @@ run-simulation: ## Run workforce simulation
 	DAGSTER_HOME="$(DAGSTER_HOME)" \
 	$(VENV)/bin/dagster dev -f definitions.py
 
-run-dashboard: ## Launch Streamlit dashboard
-	$(VENV)/bin/streamlit run streamlit_dashboard/app.py --server.port 8501
+run-dashboard: ## Launch main Streamlit dashboard
+	$(VENV)/bin/streamlit run streamlit_dashboard/main.py --server.port 8501
+
+run-compensation-tuning: ## Launch compensation tuning interface
+	$(VENV)/bin/streamlit run streamlit_dashboard/pages/1_Compensation_Tuning.py --server.port 8502
+
+run-optimization-dashboard: ## Launch optimization dashboard
+	$(VENV)/bin/streamlit run streamlit_dashboard/optimization_dashboard.py --server.port 8503
 
 docker-build: ## Build Docker image
 	docker build -t planwise-navigator:latest .


### PR DESCRIPTION
This PR updates the Makefile to properly support running Streamlit dashboards.

## Changes
- Fix run-dashboard target to use existing main.py instead of non-existent app.py
- Add run-compensation-tuning target for compensation tuning interface (port 8502)
- Add run-optimization-dashboard target for optimization dashboard (port 8503)
- Update .PHONY to include new targets

Closes #2

Generated with [Claude Code](https://claude.ai/code)